### PR TITLE
Bug Fix Android Modal Crash

### DIFF
--- a/src/views/Culture/style.ts
+++ b/src/views/Culture/style.ts
@@ -19,5 +19,5 @@ export default StyleSheet.create({
     marginHorizontal: 5,
   },
 
-  fab: { position: (Platform.OS === "web" ? "fixed" : undefined) as any },
+  fab: { position: (Platform.OS === "web" ? "fixed" : "absolute") as any },
 });

--- a/src/views/Home/Admins.tsx
+++ b/src/views/Home/Admins.tsx
@@ -1,125 +1,55 @@
-import React, { useState, useRef, useLayoutEffect } from "react";
-import { FlatList, Alert, View, Platform } from "react-native";
-import { StackNavigationProp } from "@react-navigation/stack";
+import React, { useState } from "react";
+import { FlatList, View } from "react-native";
 import { connect } from "react-redux";
 import {
   List,
   IconButton,
-  Modal,
+  Dialog,
   Portal,
-  Text,
   Button,
-  TextInput,
-  Snackbar,
+  useTheme,
 } from "react-native-paper";
-import { useFormik } from "formik";
 
-import { Routes } from "../../routes";
 import { Store } from "../../redux";
 import { Admin } from "../../lib";
 
-import Header from "../Header";
+import EditModal from "./EditModal";
 import styles from "./styles";
-import { EmailNameValidation } from "./validation";
-
-/**
- * Invite Email screen fields for Formik.
- */
-type EditFields = {
-  email: string;
-  name: string;
-};
-
-/**
- * Initial values for email field for Formik.
- */
-const initialValues: EditFields = {
-  // This field could be updated with useEffect to enter the user's saved email address.
-  email: "",
-  name: "",
-};
 
 /**
  * Properties for {@link Admins}
  */
-type AdminProps = {
+type Props = {
   token: string;
   admins: Admin[];
   theme: string;
   user: Admin;
   onRefresh: () => void;
   searchQuery?: string;
+  onErr: (err: string) => void;
 };
 
 /**
  * Component that displays a list of components of {@link Admin}
  *
- * @param {AdminProps} props
+ * @param {Props} props
  * @returns {React.ReactElement} React component
  */
-function Admins(props: AdminProps): React.ReactElement {
-  const { user, theme, token, admins, onRefresh, searchQuery } = props;
+function Admins(props: Props): React.ReactElement {
+  const { user, token, admins, onRefresh, searchQuery, onErr } = props;
+  const theme = useTheme();
 
   const [deleteModal, setDeleteModal] = useState(false);
   const [editModal, setEditModal] = useState(false);
-  const [selectedItem, setSelectedItem] = useState(null);
-  const [msg, setMsg] = useState<string>("");
-
-  const name = useRef();
-
-  const {
-    values,
-    handleChange,
-    handleBlur,
-    errors,
-    touched,
-    handleSubmit,
-    setFieldValue,
-  } = useFormik({
-    validationSchema: EmailNameValidation,
-    initialValues: initialValues,
-    onSubmit: (values) => onEdit(values),
-  });
-
-  const hideSnackbar = () => setMsg("");
+  const [selectedAdmin, setSelectedAdmin] = useState(null);
 
   const onDelete = async () => {
     try {
-      await Admin.delete(selectedItem.email, token);
-    } catch {
-      // show error message
-    }
-    onRefresh();
-  };
-
-  const onEdit = async (fields: EditFields) => {
-    const { name, email } = fields;
-    try {
-      Admin.update(email, name, props.token);
-      setEditModal(false);
+      await Admin.delete(selectedAdmin.email, token);
       onRefresh();
-    } catch {
-      // TODO: show error message
+    } catch (err) {
+      onErr(err.toString());
     }
-  };
-
-  const superUserDeleteCheck = (item: any) => {
-    if (!item.superUser && item.email != user.email)
-      return (
-        <IconButton
-          icon="delete"
-          onPress={() => {
-            setDeleteModal(true);
-            setSelectedItem(item);
-          }}
-        />
-      );
-  };
-
-  const handleEditClick = (admin: Admin) => {
-    setFieldValue("name", admin.name);
-    setFieldValue("email", admin.email);
-    setEditModal(true);
   };
 
   const searchResults = (): Admin[] => {
@@ -137,7 +67,7 @@ function Admins(props: AdminProps): React.ReactElement {
 
   return (
     <FlatList
-      style={{ flex: 1 }}
+      style={styles.list}
       data={searchResults()}
       keyExtractor={(_, index) => index.toString()}
       renderItem={({ item }) => {
@@ -147,29 +77,43 @@ function Admins(props: AdminProps): React.ReactElement {
               title={item.email}
               right={() =>
                 props.token !== "" && (
-                  <View style={{ flexDirection: "row" }}>
+                  <View style={styles.ListActions}>
                     <IconButton
                       icon="pencil"
-                      onPress={() => handleEditClick(item)}
+                      onPress={() => {
+                        setEditModal(true);
+                        setSelectedAdmin(item);
+                      }}
                     />
-                    {superUserDeleteCheck(item)}
+                    {!item.superUser && item.email != user.email && (
+                      <IconButton
+                        icon="delete"
+                        onPress={() => {
+                          setDeleteModal(true);
+                          setSelectedAdmin(item);
+                        }}
+                      />
+                    )}
                   </View>
                 )
               }
             />
             <Portal>
-              {deleteModal && (
-                <Modal
-                  visible={deleteModal}
-                  contentContainerStyle={
-                    theme === "Dark" ? styles.modalDark : styles.modalLight
-                  }
-                  onDismiss={() => setDeleteModal(false)}
-                >
-                  {/*TODO: update style for text */}
-                  <Text>
-                    Are you sure you want to delete {selectedItem.email}?
-                  </Text>
+              <Dialog
+                visible={deleteModal}
+                onDismiss={() => setDeleteModal(false)}
+                style={{ backgroundColor: theme.colors.surface }}
+              >
+                <Dialog.Title>
+                  Are you sure you want to delete {selectedAdmin?.email}?
+                </Dialog.Title>
+                <Dialog.Actions>
+                  <Button
+                    style={styles.dialogButton}
+                    onPress={() => setDeleteModal(false)}
+                  >
+                    Cancel
+                  </Button>
                   <Button
                     mode="contained"
                     onPress={() => {
@@ -180,57 +124,16 @@ function Admins(props: AdminProps): React.ReactElement {
                   >
                     Delete
                   </Button>
-                </Modal>
-              )}
-            </Portal>
-            <Portal>
-              {editModal && (
-                <Modal
-                  visible={editModal}
-                  contentContainerStyle={
-                    theme === "Dark" ? styles.modalDark : styles.modalLight
-                  }
-                  onDismiss={() => setEditModal(false)}
-                >
-                  {/*TODO: update style for text */}
-                  <Text>Edit admin Account</Text>
-                  <TextInput
-                    mode="outlined"
-                    left={<TextInput.Icon name="email" />}
-                    label="email"
-                    value={values.email}
-                    disabled={true}
-                  />
-                  <TextInput
-                    autoFocus={true}
-                    textContentType="name"
-                    mode="outlined"
-                    left={<TextInput.Icon name="account-badge" />}
-                    error={errors.name && touched.name}
-                    label="name"
-                    value={values.name}
-                    ref={name}
-                    onBlur={handleBlur("name")}
-                    onChangeText={handleChange("name")}
-                  />
-                  <View style={styles.div} />
-                  <Button mode="contained" onPress={handleSubmit}>
-                    Save
-                  </Button>
-                </Modal>
-              )}
-            </Portal>
-            <Portal>
-              <Snackbar
-                visible={msg !== ""}
-                onDismiss={hideSnackbar}
-                action={{
-                  label: "Ok",
-                  onPress: hideSnackbar,
-                }}
-              >
-                {msg}
-              </Snackbar>
+                </Dialog.Actions>
+              </Dialog>
+              <EditModal
+                show={editModal}
+                token={token}
+                admin={selectedAdmin}
+                onDismiss={() => setEditModal(false)}
+                onErr={onErr}
+                onRefresh={onRefresh}
+              />
             </Portal>
           </View>
         );

--- a/src/views/Home/EditModal.tsx
+++ b/src/views/Home/EditModal.tsx
@@ -1,0 +1,118 @@
+import React, { useRef, useEffect } from "react";
+import { useFormik } from "formik";
+import { Dialog, TextInput, Button, useTheme } from "react-native-paper";
+
+import { Admin } from "../../lib";
+
+import { EmailNameValidation } from "./validation";
+import styles from "./styles";
+
+/**
+ * Invite Email screen fields for Formik.
+ */
+type EditFields = {
+  email: string;
+  name: string;
+};
+
+/**
+ * Initial values for email field for Formik.
+ */
+const initialValues: EditFields = {
+  // This field could be updated with useEffect to enter the user's saved email address.
+  email: "",
+  name: "",
+};
+
+type Props = {
+  token: string;
+  show: boolean;
+  admin: Admin;
+  onDismiss: () => void;
+  onErr: (err: string) => void;
+  onRefresh: () => void;
+};
+
+export default function EditModal(props: Props) {
+  const { admin, token, show, onDismiss, onErr, onRefresh } = props;
+  const name = useRef();
+  const theme = useTheme();
+
+  const {
+    values,
+    handleChange,
+    handleBlur,
+    errors,
+    touched,
+    handleSubmit,
+    validateForm,
+    setFieldValue,
+  } = useFormik({
+    validationSchema: EmailNameValidation,
+    initialValues: initialValues,
+    onSubmit: (values) => update(values),
+  });
+
+  useEffect(() => {
+    setFieldValue("email", admin?.email);
+    setFieldValue("name", admin?.name);
+  }, [admin]);
+
+  const update = async (fields: EditFields) => {
+    const { name, email } = fields;
+
+    await validateForm();
+
+    try {
+      await Admin.update(email, name, token);
+      onDismiss();
+      onRefresh();
+    } catch (err) {
+      onErr(err.toString());
+    }
+  };
+
+  return (
+    <Dialog
+      visible={show}
+      onDismiss={onDismiss}
+      style={{ backgroundColor: theme.colors.surface }}
+    >
+      <Dialog.Title>Edit {admin?.name}</Dialog.Title>
+      <Dialog.Content>
+        <TextInput
+          mode="outlined"
+          style={{ paddingBottom: 10 }}
+          left={<TextInput.Icon name="email" />}
+          label="email"
+          value={values.email}
+          disabled={true}
+        />
+        <TextInput
+          autoFocus={true}
+          textContentType="name"
+          mode="outlined"
+          left={<TextInput.Icon name="account" />}
+          error={errors.name && touched.name}
+          label="name"
+          value={values.name}
+          ref={name}
+          onBlur={handleBlur("name")}
+          onChangeText={handleChange("name")}
+        />
+      </Dialog.Content>
+      <Dialog.Actions>
+        <Button style={styles.dialogButton} onPress={onDismiss}>
+          Cancel
+        </Button>
+        <Button
+          style={styles.dialogButton}
+          mode="contained"
+          onPress={handleSubmit}
+        >
+          Save
+        </Button>
+      </Dialog.Actions>
+    </Dialog>
+  );
+}

--- a/src/views/Home/InviteModal.tsx
+++ b/src/views/Home/InviteModal.tsx
@@ -1,0 +1,99 @@
+import React, { useRef } from "react";
+import { useFormik } from "formik";
+import { Dialog, TextInput, Button } from "react-native-paper";
+import { useTheme } from "react-native-paper";
+
+import { Admin } from "../../lib";
+
+import { EmailValidation } from "./validation";
+import styles from "./styles";
+
+/**
+ * Invite Email screen fields for Formik.
+ */
+type EmailField = {
+  email: string;
+};
+
+/**
+ * Initial values for email field for Formik.
+ */
+const initialValues: EmailField = {
+  // This field could be updated with useEffect to enter the user's saved email address.
+  email: "",
+};
+
+type Props = {
+  token: string;
+  show: boolean;
+  onDismiss: () => void;
+  onErr: (err: string) => void;
+};
+
+export default function InviteModal(props: Props) {
+  const { token, show, onDismiss, onErr } = props;
+  const theme = useTheme();
+
+  const email = useRef();
+  const {
+    values,
+    handleChange,
+    handleBlur,
+    errors,
+    touched,
+    handleSubmit,
+    validateField,
+  } = useFormik({
+    validationSchema: EmailValidation,
+    initialValues: initialValues,
+    onSubmit: (values) => invite(values),
+  });
+
+  const invite = async (field: EmailField) => {
+    const { email } = field;
+    await validateField("email");
+
+    try {
+      await Admin.invite(email, token);
+      onDismiss();
+    } catch (err) {
+      onErr(err.toString());
+    }
+  };
+
+  return (
+    <Dialog
+      visible={show}
+      onDismiss={onDismiss}
+      style={{ backgroundColor: theme.colors.surface }}
+    >
+      <Dialog.Title>Invite a new Admin</Dialog.Title>
+      <Dialog.Content>
+        <TextInput
+          textContentType="emailAddress"
+          autoFocus={true}
+          mode="outlined"
+          left={<TextInput.Icon name="email" />}
+          error={errors.email && touched.email}
+          label="email"
+          value={values.email}
+          ref={email}
+          onBlur={handleBlur("email")}
+          onChangeText={handleChange("email")}
+        />
+      </Dialog.Content>
+      <Dialog.Actions>
+        <Button style={styles.dialogButton} onPress={onDismiss}>
+          Cancel
+        </Button>
+        <Button
+          mode="contained"
+          style={styles.dialogButton}
+          onPress={handleSubmit}
+        >
+          Invite
+        </Button>
+      </Dialog.Actions>
+    </Dialog>
+  );
+}

--- a/src/views/Home/styles.ts
+++ b/src/views/Home/styles.ts
@@ -31,6 +31,7 @@ export default StyleSheet.create({
 
   deleteButton: {
     backgroundColor: "red",
+    margin: 5,
   },
 
   fab: {
@@ -38,5 +39,13 @@ export default StyleSheet.create({
     margin: 16,
     right: 0,
     bottom: 0,
+  },
+
+  ListActions: {
+    flexDirection: "row",
+  },
+
+  dialogButton: {
+    margin: 5,
   },
 });


### PR DESCRIPTION
Resolves: #14

## Summary

The reason the modals crashed on Android was because of the View that
had a margin of 5, which was effectively a divider. Switched to Dialogs
for displaying this content as it looks better than using Modals. Also moved the larger Modals into their own files as they were full on components. They had formik hooked in and their own operation so it seemed like a good idea to separate them.

## Acceptance Criteria

- [x] No longer broken

## Screenshots

### New Invite
![windowshot-12-05-2020-02:36:50 AM](https://user-images.githubusercontent.com/31719071/101236906-c30dde80-36a2-11eb-83fb-e78809f76ded.png)

### New Edit
![windowshot-12-05-2020-02:36:40 AM](https://user-images.githubusercontent.com/31719071/101236907-c3a67500-36a2-11eb-861b-5479b8225003.png)

